### PR TITLE
Add arbitrary-n inter-mode couplings.

### DIFF
--- a/sequencing/pulses.py
+++ b/sequencing/pulses.py
@@ -330,7 +330,7 @@ class SmoothedConstantPulse(Pulse):
             in radians. Default: 0.
         length (int): Total length of the pulse in ns. Default: 100.
         sigma (int): Ring-up and ring-down time in ns. If sigma == 0, then
-            this is equivalent to ControlPulse. The length of the contant
+            this is equivalent to ControlPulse. The length of the constant
             portion of the pulse is ``length - 2 * sigma``. Default: 0.
         shape (str): String specifying the type of ring-up and ring-down.
             Calid options are 'tanh' and 'cos' (see ``ringup_wave``).

--- a/sequencing/pulses.py
+++ b/sequencing/pulses.py
@@ -333,7 +333,7 @@ class SmoothedConstantPulse(Pulse):
             this is equivalent to ControlPulse. The length of the constant
             portion of the pulse is ``length - 2 * sigma``. Default: 0.
         shape (str): String specifying the type of ring-up and ring-down.
-            Calid options are 'tanh' and 'cos' (see ``ringup_wave``).
+            Valid options are 'tanh', 'cos', and 'gaussian' (see ``ringup_wave``).
             Default: 'tanh'.
     """
 

--- a/sequencing/sequencing/basic.py
+++ b/sequencing/sequencing/basic.py
@@ -149,7 +149,7 @@ class HamiltonianChannels(object):
         if times is None:
             if t0 is None or duration is None:
                 raise ValueError(
-                    "You must either specify an array of times " "or t0 and duration."
+                    "You must either specify an array of times or t0 and duration."
                 )
             delay = int(channel_dict[channel_name]["delay"])
             times = np.arange(t0 + delay, t0 + delay + duration, self.dt)

--- a/sequencing/system.py
+++ b/sequencing/system.py
@@ -494,7 +494,7 @@ class System(Parameterized):
             d = json.loads(json_str, object_hook=json_decode)
         else:
             if json_path is None:
-                raise ValueError("You must provide either json_path " "or json_str.")
+                raise ValueError("You must provide either json_path or json_str.")
             if not json_path.endswith(".json"):
                 json_path = json_path + ".json"
             with open(json_path, "r") as f:

--- a/sequencing/system.py
+++ b/sequencing/system.py
@@ -57,7 +57,7 @@ class CouplingTerm(object):
                 raise TypeError(f"Expected instance of Mode, but got {type(mode)}.")
             if not isinstance(expr, str):
                 raise TypeError(f"Expected instance of str, but got {type(expr)}.")
-        self.terms = terms
+        self.terms = list(terms)
         self.strength = float(strength)
         self.add_hc = bool(add_hc)
 

--- a/sequencing/system.py
+++ b/sequencing/system.py
@@ -28,11 +28,11 @@ class CouplingTerm(object):
     ``strength * (product(operators) + product(operators).dag())``.
 
     Args:
-        terms (list[tuple[Mode, str]]): List of tuples of `(mode, expr)`,
-            which defines the coupling. Each `expr` is a string containing an
+        terms (list[tuple[Mode, str]]): List of tuples of ``(mode, expr)``,
+            which defines the coupling. Each ``expr`` is a string containing an
             algebraic expression involving the Mode's operators.
             See :func:`Mode.operator_expr` for more details.
-            The resulting operators are given by `mode.operator_expr(expr)`.
+            The resulting operators are given by ``mode.operator_expr(expr)``.
         strength (optional, float): Coefficient parameterizing the
             strength of the coupling. Strength should be given in
             units of 2 * pi * GHz. Default: 1.


### PR DESCRIPTION
This is backwards compatible with the old signature for CouplingTerm.__init__().